### PR TITLE
Fix double %U

### DIFF
--- a/browser/default.nix
+++ b/browser/default.nix
@@ -199,7 +199,7 @@ stdenv.mkDerivation rec {
     substituteInPlace $out/share/applications/${desktopName}.desktop \
        --replace /usr/ $out/
     substituteInPlace $out/share/applications/${desktopName}.desktop \
-       --replace "Exec=$out/bin/${pname}" "Exec=$out/bin/${pname} %U"
+       --replace "Exec=$out/bin/${pname}" "Exec=$out/bin/${pname}"
     yaBinary=$out/opt/yandex/${folderName}/${binName}
     chmod +x $yaBinary
     patchelf --set-rpath "${rpath}" "$yaBinary"


### PR DESCRIPTION
```
❯ grep "%U" ./2mp855nbfbf6r51466mglsya2gpfxrb3-yandex-browser-stable-25.2.1.939-1/share/applications/yandex-browser.desktop
Exec=/nix/store/2mp855nbfbf6r51466mglsya2gpfxrb3-yandex-browser-stable-25.2.1.939-1/bin/yandex-browser-stable %U %U
Exec=/nix/store/2mp855nbfbf6r51466mglsya2gpfxrb3-yandex-browser-stable-25.2.1.939-1/bin/yandex-browser-stable %U
Exec=/nix/store/2mp855nbfbf6r51466mglsya2gpfxrb3-yandex-browser-stable-25.2.1.939-1/bin/yandex-browser-stable %U --incognito
```