### PR TITLE
Update default.nix

### DIFF
--- a/browser/default.nix
+++ b/browser/default.nix
@@ -4,7 +4,7 @@
 , lib
 , fetchurl
 , autoPatchelfHook
-, wrapGAppsHook
+, wrapGAppsHook3
 , flac
 , gnome2
 , harfbuzzFull
@@ -169,7 +169,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     autoPatchelfHook
-    wrapGAppsHook
+    wrapGAppsHook3
     makeWrapper
   ];
 


### PR DESCRIPTION
Привет!

в алиасах добавили throw для старых переименований и сборка падает

```
         1571|   wpa_supplicant_ro_ssids = throw "'wpa_supplicant_ro_ssids' has been renamed to/replaced by 'wpa_supplicant'"; # Converted to throw 2025-10-27
         1572|   wrapGAppsHook = throw "'wrapGAppsHook' has been renamed to/replaced by 'wrapGAppsHook3'"; # Converted to throw 2025-10-27
             |                   ^
         1573|   write_stylus = throw "'write_stylus' has been renamed to/replaced by 'styluslabs-write-bin'"; # Converted to throw 2025-10-27

       error: 'wrapGAppsHook' has been renamed to/replaced by 'wrapGAppsHook3'
```