### PR TITLE
fix(wayland): Resolve rendering issues on NVIDIA

### DIFF
--- a/browser/default.nix
+++ b/browser/default.nix
@@ -205,9 +205,8 @@ stdenv.mkDerivation rec {
     patchelf --set-rpath "${rpath}" "$yaBinary"
     makeWrapper $out/opt/yandex/${folderName}/${binName} "$out/bin/${pname}" \
       --prefix LD_LIBRARY_PATH : "${rpath}" \
-      --add-flags "--gl=egl-angle --angle=opengl" \
-      --add-flags "--enable-features=Vulkan,VulkanFromANGLE,DefaultANGLEVulkan,VaapiVideoDecoder,VaapiVideoEncoder,UseMultiPlaneFormatForHardwareVideo" \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
+      --add-flags "--enable-features=Vulkan,VulkanFromANGLE,DefaultANGLEVulkan,VaapiVideoDecoder,VaapiVideoEncoder,UseMultiPlaneFormatForHardwareVideo,WaylandWindowDecorations,UseOzonePlatform" \
+      --add-flags "''${NIXOS_OZONE_WL:+''${WAYLAND_DISPLAY:+--ozone-platform=wayland --use-gl=egl}}"
     ln -s ${codecs}/lib/libffmpeg.so $out/opt/yandex/${folderName}/libffmpeg.so
     ln -s ${codecs}/codecs_checksum $out/opt/yandex/${folderName}/codecs_checksum
     sed -e '90iexport FOUND_FFMPEG=1' -i $out/opt/yandex/${folderName}/${binName}


### PR DESCRIPTION
Отвалилось все на Nvidia и Wayland, были ошибки вида:
```
[28247:28247:1107/015933.776916:ERROR:wayland_event_watcher.cc:47] libwayland:   wl_shm_pool#44 still attache
...
[29872:29896:1107/020122.905361:ERROR:parsed_gpu_control_list.cc:699] disable_direct_composition
```

Изменения:
 - Убрал `--gl=egl-angle --angle=opengl`
 - Добавил `--ozone-platform=wayland` вместо `--ozone-platform-hint=auto`
 - Добавил `--use-gl=egl`
 - Добавил `WaylandWindowDecorations` и `UseOzonePlatform`
 
Сейчас работает.  

На X11 работу не проверял, но по идее не должно затронуть. 