### PR TITLE
feat: add commandLineArgs and support NIXOS_OZONE_WL=0

### DIFF
--- a/browser/default.nix
+++ b/browser/default.nix
@@ -59,6 +59,7 @@
   libglvnd,
   libpulseaudio,
   extensions ? [ ],
+  commandLineArgs ? [ ],
 }:
 
 let
@@ -199,7 +200,9 @@ stdenv.mkDerivation {
         export LD_LIBRARY_PATH="${rpath}:${addDriverRunpath.driverLink}/lib''${LD_LIBRARY_PATH:+:''$LD_LIBRARY_PATH}"
 
         FLAGS=""
-        if [ -n "$WAYLAND_DISPLAY" ] || [ "$XDG_SESSION_TYPE" = "wayland" ]; then
+        if [ "''${NIXOS_OZONE_WL:-}" = "0" ]; then
+          FLAGS="$FLAGS --ozone-platform=x11"
+        elif [ -n "$WAYLAND_DISPLAY" ] || [ "$XDG_SESSION_TYPE" = "wayland" ]; then
           export NIXOS_OZONE_WL=1
           FLAGS="$FLAGS --ozone-platform=wayland"
 
@@ -214,7 +217,8 @@ stdenv.mkDerivation {
       ' \
       --add-flags "--ignore-gpu-blocklist" \
       --add-flags "--enable-features=VaapiVideoDecoder,WebRTCPipeWireCapturer,CanvasOopRasterization,WaylandWindowDecorations,WebGPU" \
-      --add-flags "\''${YANDEX_FLAGS:-}"
+      --add-flags "\''${YANDEX_FLAGS:-}" \
+      ${lib.concatMapStringsSep " " (x: "--add-flags ${lib.escapeShellArg x}") commandLineArgs}
 
     runHook postInstall
   '';


### PR DESCRIPTION
Добавил параметр `commandLineArgs` для проброса кастомных флагов в обертку браузера (по аналогии с Chrome из nixpkgs).

Также добавил проверку переменной `NIXOS_OZONE_WL`. Если запустить браузер с `NIXOS_OZONE_WL=0`, обертка принудительно переключит на X11. Это позволяет обойти краши под Wayland (например, в KDE) без необходимости писать костыли с `builtins.replaceStrings` в конфигах.


Можно запустить из терминала: `NIXOS_OZONE_WL=0 yandex-browser-stable`, либо 
```nix
yandex-browser-stable.override {
  commandLineArgs = [ "--ozone-platform=x11" ];
}
```